### PR TITLE
Update versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:experimental
-ARG BASE=ubuntu:22.04
+ARG BASE=ubuntu:24.04
 
 # build is based on https://coder.com/docs/code-server/latest/CONTRIBUTING
-FROM node:18.18.2-bookworm as build
+FROM node:20.17-bookworm as build
 
-ARG CODE_SERVER_VERSION=4.18.0
-ARG VS_CODE_VERSION=1.83.1
+ARG CODE_SERVER_VERSION=4.93.1
+ARG VS_CODE_VERSION=1.93.1
 
 RUN echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 RUN apt-get update --allow-insecure-repositories


### PR DESCRIPTION
Needed to build a container for my ARM based Mac to run code server locally while developing a lab. Saw Yarn/Node/Gyp error when building. Updated the versions of everything to the latest appears to resolve this.

Not sure if it's necessary or a good idea to update the ghcr image to be multi-platform (since we can easily build it locally).

I presume when building the workspace/content images before publishing IDE labs, we should be targeting x86_64 using the `--platform` option. E.g.

```
docker build \
  --platform linux/amd64
  --tag <IMAGE_NAME> \
  --push
```